### PR TITLE
Add support paths with numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "glob": "^7.1.7",
         "mocha": "^10.1.0",
         "prettier": "2.3.2",
-        "typescript": "^4.3.2",
+        "typescript": "^4.4.0",
         "vsce": "^2.15.0",
         "vscode-test": "^1.5.2"
       },
@@ -3902,10 +3902,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "glob": "^7.1.7",
     "mocha": "^10.1.0",
     "prettier": "2.3.2",
-    "typescript": "^4.3.2",
+    "typescript": "^4.4.0",
     "vsce": "^2.15.0",
     "vscode-test": "^1.5.2"
   },

--- a/src/json.path.ts
+++ b/src/json.path.ts
@@ -87,9 +87,14 @@ export function getPropertyPathWithQuotes(
   return `[${propertyNameJson}]`;
 }
 
-export const nonQuotedCharacterRanges = ['A-Z', 'À-Ö', 'Ø-ö', 'ø-ÿ'];
+export const nonQuotedCharacterRanges = ['A-Z', 'À-Ö', 'Ø-ö', 'ø-ÿ', '0-9'];
 
 export function propertyRequiresQuotes(propertyName: jsonc.Segment): boolean {
+  // If the property start with a numbrer we are forced to require quotes
+  if (propertyName.toString().match(/^\d/)) {
+    return true;
+  }
+  
   // https://stackoverflow.com/questions/20690499/concrete-javascript-regular-expression-for-accented-characters-diacritics/26900132#26900132
   const allowedCharRanges = nonQuotedCharacterRanges.join('');
   const allowedCharactersWithoutEscaping = new RegExp(


### PR DESCRIPTION
We have discovered that some specific paths are not properly build.

If your JSON content is something like:

```json
{
  "foo": {
       "bar2": "baz"
   }
}
```

The exported json path is `foo.["bar2"]`. This commit solves this issue.