### PR TITLE
feat: add keybindings for copy cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,16 @@
         "group": "myGroup@1"
       }
     ],
+    "keybindings": [
+      {
+        "command": "copy-json-path.copy",
+        "key": "cmd+alt+c",
+        "mac": "cmd+alt+c",
+        "linux": "ctrl+alt+c",
+        "windows": "ctrl+alt+c",
+        "when": "editorTextFocus && (editorLangId == 'json' || editorLangId == 'jsonc')"
+      }
+    ],
     "configuration": {
       "title": "Copy Json Path",
       "properties": {


### PR DESCRIPTION
Add the keybindings shortcut `ctrl+alt+c` to execute the copy command inside a `json(c)` file

close #24 